### PR TITLE
updated Readme to include info on how to persist MySQL DB data when m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,76 @@ docker compose up
 ```
 
 That should build the image and launch the containers. If everything works, you should be able to see the NADA installer at http://localhost:8383/.
+
+### Persist the MySQL data
+
+#### Create a new directy called mysql-data under nada_docker directory
+
+```bash
+mkdir mysql-data
+```
+
+#### Stop the MySQL docker container
+
+```bash
+docker stop mysql
+```
+
+#### Copy the existing MySQL database files from within the container as initial data
+
+```bash
+sudo docker cp mysql:/var/local/mysql ./mysql-data
+```
+
+#### Update the docker-compose.yml file
+
+Updated file should look like the following below with new volume mount point for the MySQL database files.
+
+```bash
+version: '3'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: nada_docker
+    ports:
+      - "127.0.0.1:8383:80"
+    volumes:
+      - ./nada:/var/www/html/nada
+    links:
+      - mysql
+    environment:
+      DB_HOST: mysql
+      DB_DATABASE: nada_docker
+      DB_USERNAME: nada_user
+      DB_PASSWORD: nada_password      
+
+  mysql:
+    image: mysql:5.7
+    container_name: mysql-57
+    restart: always
+    ports:
+      - 13306:3306
+    environment:
+      MYSQL_DATABASE: nada_docker
+      MYSQL_USER: nada_user
+      MYSQL_PASSWORD: nada_password
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - ./mysql-data:/var/lib/mysql
+```
+
+#### Remove the docker container and start it back up
+
+Open a new terminal and enter the commands below.
+
+```bash
+docker rm mysql
+```
+
+```bash
+docker compose up
+```
+
+Now when the mysql database container is stopped and removed, the data is persisted on the mounted volume directory.


### PR DESCRIPTION
updated Readme to include info on how to persist MySQL DB data when mysql container is removed and restarted.

This is important because the host can be restarted and the containers removed and reverted back to the install state. This may not be an unwanted screnario as I have faced.